### PR TITLE
fix(release): add title and auto-generated notes to releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,4 +154,6 @@ jobs:
         GH_TOKEN: ${{ secrets.WORKFLOW_USER_GH_TOKEN }}
       run: |
         gh release create ${{ steps.get_target_release.outputs.tag }} \
-          --target "${{ steps.get_target_commit.outputs.sha }}"
+          --target "${{ steps.get_target_commit.outputs.sha }}" \
+          --title "${{ steps.get_target_release.outputs.tag }}" \
+          --generate-notes


### PR DESCRIPTION
## Summary

- The `gh release create` command was missing `--title` and `--generate-notes` flags
- This caused releases to be created with `null` names and empty bodies
- Adds `--title` (set to the tag name, e.g. `v0.3.72`) and `--generate-notes` (auto-generates structured release notes from PRs/commits since the previous tag)

## Context

Discovered while backfilling release notes for 70 existing releases that were all missing notes and had no name set.

## Test plan

- [ ] Trigger a manual release via `workflow_dispatch` and verify it has a clean title and auto-generated notes