### PR TITLE
feat: use categorized conventional-commit release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -148,6 +148,16 @@ jobs:
         failStepIfUnsuccessful: true
         appSlugFilter: github-actions
 
+    - name: Generate release notes
+      id: release_notes
+      if: steps.get_target_release.outputs.create_release == 'true'
+      uses: SAP/cs-actions/generate-release-notes-action@main
+      with:
+        personal-token: ${{ secrets.WORKFLOW_USER_GH_TOKEN }}
+        new-tag: ${{ steps.get_target_release.outputs.tag }}
+        previous-tag: ${{ steps.get_current_release.outputs.tag }}
+        target-ref: ${{ steps.get_target_commit.outputs.sha }}
+
     - name: Create Release
       if: steps.get_target_release.outputs.create_release == 'true'
       env:
@@ -156,4 +166,4 @@ jobs:
         gh release create ${{ steps.get_target_release.outputs.tag }} \
           --target "${{ steps.get_target_commit.outputs.sha }}" \
           --title "${{ steps.get_target_release.outputs.tag }}" \
-          --generate-notes
+          --notes "${{ steps.release_notes.outputs.release-notes }}"


### PR DESCRIPTION
## Summary

- Replaces `--generate-notes` (GitHub's generic auto-format) with `SAP/cs-actions/generate-release-notes-action@main`
- Future releases will have categorized notes based on conventional commit prefixes:
  - **Breaking Changes** (`feat!:`, `fix!:`, etc.)
  - **New Features** (`feat:`)
  - **Bug Fixes** (`fix:`)
  - **Improvements** (`chore:`, `refactor:`, `ci:`, `build:`, `perf:`, etc.)
  - **Documentation** (`docs:`)
  - **Other Changes** (non-conventional commits)
- Existing 74 releases have already been backfilled with this format

### Before (GitHub auto-generated)
```
## What's Changed
* chore(deps): update dependency autoprefixer to v10.5.0 by @renovate in #132
**Full Changelog**: https://github.com/SAP/clustersecret-operator/compare/v0.3.72...v0.3.73
```

### After (conventional-commit categorized)
```
## What's Changed

### 🔧 Improvements
- update dependency autoprefixer to v10.5.0 (#132) (9e5b8b8)

**Full Changelog**: https://github.com/SAP/clustersecret-operator/compare/v0.3.72...v0.3.73
```

## Test plan

- [x] Backfilled all 74 existing releases with new format — verified on GitHub
- [x] Validated action output via Compare API simulation (v0.3.60...v0.3.73)
- [x] Trigger a manual `workflow_dispatch` release after merge to confirm end-to-end

The following release was created after merging this PR and manually triggering release workflow:

https://github.com/SAP/clustersecret-operator/releases/tag/v0.3.74

<img width="1219" height="630" alt="image" src="https://github.com/user-attachments/assets/6478bb8c-d2ec-4d76-8834-761f68cfd8fa" />
