### PR TITLE
ci: add generate workflow

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -1,0 +1,36 @@
+name: Update generated artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  generate:
+    name: Update generated artifacts
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Setup go
+      uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
+
+    - name: Update generated artifacts
+      run: |
+        go mod tidy
+        make generate
+
+        git config user.name "${{ vars.WORKFLOW_USER_NAME }}"
+        git config user.email "${{ vars.WORKFLOW_USER_EMAIL }}"
+        git add -A
+        git diff --cached --quiet || git commit -m "Update generated artifacts"
+        git push


### PR DESCRIPTION
## Summary

Adds the missing `generate.yaml` workflow to allow maintainers (and automation) to regenerate code artifacts via `workflow_dispatch`.

## Context

`clustersecret-operator` uses `k8s.io/code-generator` and maintains generated code under `pkg/client/` (deepcopy, typed client, listers, informers, applyconfigs). The `build.yaml` CI enforces that these artifacts are up-to-date on every PR (step: *Check that generated artifacts are up-to-date*). All other operator repos in the `sap-cs-devops` family with the same stack already have this workflow ([component-operator](https://github.com/SAP/component-operator), [project-operator](https://github.com/SAP/project-operator), [dns-masquerading-operator](https://github.com/SAP/dns-masquerading-operator), etc.); `clustersecret-operator` was the only one missing it.

This gap caused PR [#136](https://github.com/SAP/clustersecret-operator/pull/136) (Renovate: bump `k8s.io/code-generator` `v0.36.0 → v0.36.2`) to fail repeatedly because there was no workflow to regenerate and commit the updated artifacts.

A colleague previously attempted to add this workflow directly on the Renovate branch, but the temporary version failed with:
```
make: *** No rule to make target 'manifests'. Stop.
```
because it was copied from repos that use `controller-gen` and have a `make manifests` target. This repo does **not** — it only needs `make generate`.

## Changes

- `.github/workflows/generate.yaml` — new file, triggered via `workflow_dispatch` only
  - Runs `go mod tidy` + `make generate` (calls `hack/update-codegen.sh`)
  - Guards the commit with `git diff --cached --quiet ||` so the job doesn't fail when artifacts are already up-to-date
  - **No `make manifests`** — this repo has no `controller-gen`/CRD manifests target

## How to use

To unblock PR #136 (or any future Renovate PR that bumps code-generator deps):
1. Go to **Actions → Update generated artifacts → Run workflow**
2. Select the Renovate branch (e.g. `renovate/non-minor-deps`)
3. The workflow commits the regenerated artifacts directly to the branch
4. The `build.yaml` check then passes on the next push